### PR TITLE
Drop multiple databases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+node_modules/**/*
 .idea
 npm-debug.log

--- a/README.md
+++ b/README.md
@@ -9,12 +9,19 @@ Installing
     npm install grunt-mongo-drop-task
 
     specify options grunt.initConfig:
-    'mongo-drop': {
-                options: {
-                    dbname: 'mean-dev',
+
+        'mongo-drop': {
+            options: {
+                databases: [{
+                    dbname: 'database1',
                     host: 'localhost'
-                }
+                },
+                {
+                    dbname: 'database2',
+                    host: 'localhost'
+                }]
             }
+        }
 
     and then you can use it e.g. grunt.registerTask('drop', ['mongo-drop']);
 
@@ -22,5 +29,7 @@ Installing
 Options with default values
 -----------------
 
-     dbname: null
-     host: 'localhost'
+    databases: [{
+        dbname: null,
+        host: 'localhost'
+    }]

--- a/package.json
+++ b/package.json
@@ -1,24 +1,27 @@
 {
-    "name": "grunt-mongo-drop-task",
-    "version": "0.1.0",
-    "description": "Grunt task to drop mongo database",
-    "scripts": {
-        "test": "echo \"Error: no test specified\" && exit 1"
-    },
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/IOKI/grunt-mongo-drop.git"
-    },
-    "keywords": [
-        "Pearson",
-        "Mongo",
-        "Drop",
-        "Grunt"
-    ],
-    "author": "Filip Madejek <filip.madejek@pearson.com>",
-    "license": "MIT",
-    "bugs": {
-        "url": "https://github.com/IOKI/grunt-mongo-drop/issues"
-    },
-    "homepage": "https://github.com/IOKI/grunt-mongo-drop"
+  "name": "grunt-mongo-drop-task",
+  "version": "0.1.0",
+  "description": "Grunt task to drop mongo database",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/IOKI/grunt-mongo-drop.git"
+  },
+  "keywords": [
+    "Pearson",
+    "Mongo",
+    "Drop",
+    "Grunt"
+  ],
+  "author": "Filip Madejek <filip.madejek@pearson.com>",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/IOKI/grunt-mongo-drop/issues"
+  },
+  "homepage": "https://github.com/IOKI/grunt-mongo-drop",
+  "dependencies": {
+    "mongoose": "4.5.8"
+  }
 }

--- a/tasks/gruntMongoDrop.js
+++ b/tasks/gruntMongoDrop.js
@@ -24,13 +24,13 @@ module.exports = function (grunt) {
 
         grunt.verbose.writeln('dropping: ' + options.databases[i].dbname);
 
-        db = mongoose.connect('mongodb://' + options.databases[i].host + '/' + options.databases[i].dbname, function (err) {
+        var connection = mongoose.createConnection('mongodb://' + options.databases[i].host + '/' + options.databases[i].dbname, function (err) {
           if (err) {
             grunt.log.writeln('Could not connect to mongodb, check if mongo is running');
             done(err);
           } else {
             grunt.log.writeln('Open db connection');
-            db.connection.db.dropDatabase(function (err) {
+            connection.db.dropDatabase(function (err) {
               if (err) {
                 grunt.log.writeln('Could not drop database');
                 done(err);

--- a/tasks/gruntMongoDrop.js
+++ b/tasks/gruntMongoDrop.js
@@ -18,6 +18,7 @@ module.exports = function (grunt) {
 
     grunt.verbose.writeflags(options, 'Options');
 
+    var closedCount = 0;
     for (var i = 0; i < options.databases.length; i++) {
 
       if (options.databases[i].dbname !== null) {
@@ -36,7 +37,11 @@ module.exports = function (grunt) {
                 done(err);
               } else {
                 grunt.log.writeln('Database dropped');
-                done();
+                
+                ++closedCount;
+                if (closedCount === options.databases.length) {
+                    done();
+                }
               }
             });
           }

--- a/tasks/gruntMongoDrop.js
+++ b/tasks/gruntMongoDrop.js
@@ -1,35 +1,47 @@
 'use strict';
 
-module.exports = function(grunt) {
-    return grunt.registerTask('mongo-drop', 'Drop mongodb database.', function() {
-        var options,
-            mongoose = require('mongoose'),
-            done = this.async(),
-            db;
+module.exports = function (grunt) {
+  return grunt.registerTask('mongo-drop', 'Drop mongodb database.', function () {
 
-        options = this.options({
-            dbname: null,
-            host: 'localhost'
-        });
+    var options,
+      mongoose = require('mongoose'),
+      done = this.async(),
+      db;
 
-        grunt.verbose.writeflags(options, 'Options');
+    options = this.options(
+      {
+        databases: [{
+          dbname: null,
+          host: 'localhost'
+        }]
+      });
 
-        db = mongoose.connect('mongodb://' + options.host + '/' + options.dbname, function(err) {
-            if (err) {
-                grunt.log.writeln('Could not connect to mongodb, check if mongo is running');
+    grunt.verbose.writeflags(options, 'Options');
+
+    for (var i = 0; i < options.databases.length; i++) {
+
+      if (options.databases[i].dbname !== null) {
+
+        grunt.verbose.writeln('dropping: ' + options.databases[i].dbname);
+
+        db = mongoose.connect('mongodb://' + options.databases[i].host + '/' + options.databases[i].dbname, function (err) {
+          if (err) {
+            grunt.log.writeln('Could not connect to mongodb, check if mongo is running');
+            done(err);
+          } else {
+            grunt.log.writeln('Open db connection');
+            db.connection.db.dropDatabase(function (err) {
+              if (err) {
+                grunt.log.writeln('Could not drop database');
                 done(err);
-            } else {
-                grunt.log.writeln('Open db connection');
-                db.connection.db.dropDatabase(function(err) {
-                    if (err) {
-                        grunt.log.writeln('Could not drop database');
-                        done(err);
-                    } else {
-                        grunt.log.writeln('Database dropped');
-                        done();
-                    }
-                });
-            }
+              } else {
+                grunt.log.writeln('Database dropped');
+                done();
+              }
+            });
+          }
         });
-    });
+      }
+    }
+  });
 };


### PR DESCRIPTION
Allow the user to specify multiple databases to drop in the task options.

Also adds the mongoose dependency explicitly.
